### PR TITLE
PHPC-408: Ensure object_to_bson() always creates a BSON document

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -717,6 +717,11 @@ void object_to_bson(zval *object, php_phongo_bson_flags_t flags, const char *key
 			return;
 		}
 	}
+
+	/* Even if we don't know how to encode the object, ensure that we at least
+	 * create an empty BSON document. */
+	bson_append_document_begin(bson, key, key_len, &child);
+	bson_append_document_end(bson, &child);
 }
 void phongo_bson_append(bson_t *bson, php_phongo_bson_flags_t flags, const char *key, long key_len, int entry_type, zval *entry TSRMLS_DC)
 {

--- a/tests/bson/bson-utcdatetime-001.phpt
+++ b/tests/bson/bson-utcdatetime-001.phpt
@@ -51,8 +51,8 @@ Test#1 { "0" : { "$date" : 1416445411987 } }
 string(37) "{ "0" : { "$date" : 1416445411987 } }"
 string(37) "{ "0" : { "$date" : 1416445411987 } }"
 bool(true)
-Test#2 { }
-string(3) "{ }"
-string(3) "{ }"
+Test#2 { "0" : {  } }
+string(14) "{ "0" : {  } }"
+string(14) "{ "0" : {  } }"
 bool(false)
 ===DONE===

--- a/tests/bson/bson-utcdatetime-001.phpt
+++ b/tests/bson/bson-utcdatetime-001.phpt
@@ -12,21 +12,21 @@ $manager = new MongoDB\Driver\Manager(STANDALONE);
 
 $classname = BSON_NAMESPACE . "\\UTCDateTime";
 $utcdatetime = new $classname("1416445411987");
-$result = $manager->executeInsert(NS, array('_id' => 1, 'x' => $utcdatetime));
+
+$manager->executeInsert(NS, array('_id' => 1, 'x' => $utcdatetime));
+
 $query = new MongoDB\Driver\Query(array('_id' => 1));
 $cursor = $manager->executeQuery(NS, $query);
-$array = iterator_to_array($cursor);
+$results = iterator_to_array($cursor);
 
-
-$date = $utcdatetime->toDateTime();
-var_dump($date->format(DATE_RSS));
-
-echo $utcdatetime, "\n";
+$datetime = $utcdatetime->toDateTime();
+var_dump($datetime->format(DATE_RSS));
+var_dump((string) $utcdatetime);
 
 $tests = array(
     array($utcdatetime),
-    array($array[0]->x),
-    array($date),
+    array($results[0]->x),
+    array($datetime),
 );
 
 foreach($tests as $n => $test) {
@@ -42,7 +42,7 @@ foreach($tests as $n => $test) {
 <?php exit(0); ?>
 --EXPECTF--
 string(31) "Thu, 20 Nov 2014 01:03:31 +0000"
-1416445411987
+string(13) "1416445411987"
 Test#0 { "0" : { "$date" : 1416445411987 } }
 string(37) "{ "0" : { "$date" : 1416445411987 } }"
 string(37) "{ "0" : { "$date" : 1416445411987 } }"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-408